### PR TITLE
[#15] [UI] As a user, I can delete a shortened link

### DIFF
--- a/ShortenLink/Resources/Localize/en.lproj/Localizable.strings
+++ b/ShortenLink/Resources/Localize/en.lproj/Localizable.strings
@@ -18,3 +18,8 @@
 
 "linksPopOver.titletext.title" = "Nimble Link";
 
+"shortenLinkCell.deleteAlert.title" = "Are you sure to delete this Nimble Link “%@”?";
+"shortenLinkCell.deleteAlert.message" = "This action cannot be undone.";
+"shortenLinkCell.deleteAlert.deleteButton.title" = "Delete";
+"shortenLinkCell.deleteAlert.cancelButton.title" = "Cancel";
+

--- a/ShortenLink/Scenes/LinksPopOver/Cell/ShortenLinkCellView.swift
+++ b/ShortenLink/Scenes/LinksPopOver/Cell/ShortenLinkCellView.swift
@@ -135,19 +135,16 @@ extension ShortenLinkCellView {
         guard let window = self.window else { return }
         let alert = NSAlert()
         alert.icon = NSImage(named: NSImage.cautionName)
-        alert.messageText = """
-        "Are you sure to delete this Nimble Link “https://nimble-link/example-for-a-typing-alias-someID1234567890”?
-
-        This action cannot be undone.
-        """
-        alert.addButton(withTitle: "Delete")
-        alert.addButton(withTitle: "Cancel")
+        let shortenLink = viewModel?.output.shortenLink ?? ""
+        alert.messageText = L10n.ShortenLinkCell.DeleteAlert.title(shortenLink)
+        alert.informativeText = L10n.ShortenLinkCell.DeleteAlert.message
+        alert.addButton(withTitle: L10n.ShortenLinkCell.DeleteAlert.DeleteButton.title)
+        alert.addButton(withTitle: L10n.ShortenLinkCell.DeleteAlert.CancelButton.title)
         alert.buttons[0].highlight(true)
         alert.alertStyle = .warning
 
         alert.beginSheetModal(for: window, completionHandler: { [weak self] modalResponse -> Void in
             if modalResponse == .alertFirstButtonReturn {
-                print("Document deleted")
                 self?.viewModel?.input.deleteLinkTapped.accept(())
             }
         })


### PR DESCRIPTION
#15

## What happened 👀

Show a confirmation popup:
message: Are you sure to delete this Nimble Link “shortened link”?
additional message: This action cannot be undone.
2 buttons: cancel and delete
 
## Insight 📝
<img width="341" alt="Screen Shot 2021-11-23 at 11 05 10" src="https://user-images.githubusercontent.com/6356137/142969835-23938773-2328-4f34-850a-a700c89c4ed8.png">

https://user-images.githubusercontent.com/6356137/142969840-155cc994-101d-44c6-81e6-3e2a71638e55.mp4


Use NSAlert.
 
## Proof Of Work 📹

